### PR TITLE
Bootstrap Next.js frontend (mandabrain-v2) with auth, UI components, docs, tests and CI

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,32 @@
+name: web-ci
+
+on:
+  push:
+    paths:
+      - 'mandabrain-v2/apps/web/**'
+      - '.github/workflows/web-ci.yml'
+  pull_request:
+    paths:
+      - 'mandabrain-v2/apps/web/**'
+      - '.github/workflows/web-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mandabrain-v2/apps/web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# -----------------------------
+# IDE / editor
+# -----------------------------
+.idea/
+.vscode/
+*.iml
+
+# -----------------------------
+# OS files
+# -----------------------------
+.DS_Store
+Thumbs.db
+
+# -----------------------------
+# Node / Next.js (monorepo-safe)
+# -----------------------------
+node_modules/
+**/node_modules/
+.next/
+**/.next/
+out/
+**/out/
+coverage/
+**/coverage/
+dist/
+**/dist/
+*.tsbuildinfo
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# -----------------------------
+# Environment files
+# -----------------------------
+.env
+.env.*
+**/.env
+**/.env.*
+
+# Keep sample env files versioned
+!.env.example
+!**/.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  mysql_legacy:
+    image: mysql:8.0
+    container_name: mandabrain_mysql_legacy
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: root_legacy
+      MYSQL_DATABASE: mandabrain_legacy
+      MYSQL_USER: mandabrain
+      MYSQL_PASSWORD: mandabrain
+    ports:
+      - "3307:3306"
+    volumes:
+      - mysql_legacy_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot_legacy"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  postgres_v2:
+    image: postgres:16
+    container_name: mandabrain_postgres_v2
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: mandabrain_v2
+      POSTGRES_USER: mandabrain
+      POSTGRES_PASSWORD: mandabrain
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_v2_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mandabrain -d mandabrain_v2"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  mysql_legacy_data:
+  postgres_v2_data:

--- a/docs/BANCO_DADOS.md
+++ b/docs/BANCO_DADOS.md
@@ -1,0 +1,57 @@
+# Como visualizar o banco de dados (legado e v2)
+
+## 1) Banco legado (MySQL do projeto atual)
+
+O dump está em `mandabrain.sql`.
+
+### Opção A — via DBeaver / DataGrip / TablePlus
+
+1. Crie uma conexão MySQL.
+2. Host: `127.0.0.1`
+3. Porta: `3306`
+4. Usuário: `root` (ou o usuário do seu ambiente)
+5. Banco: `mandabrain`
+6. Importe o dump `mandabrain.sql`.
+
+### Opção B — via terminal
+
+```bash
+mysql -u root -p
+CREATE DATABASE IF NOT EXISTS mandabrain;
+USE mandabrain;
+SOURCE mandabrain.sql;
+SHOW TABLES;
+```
+
+## 2) Consultas úteis para entendimento rápido
+
+```sql
+-- Listar tabelas
+SHOW TABLES;
+
+-- Ver estrutura da tabela de usuários
+DESCRIBE usuario;
+
+-- Amostra de usuários
+SELECT idUsuario, nome, email, idTipoUsuario FROM usuario LIMIT 20;
+```
+
+## 3) Banco v2 (quando subirmos PostgreSQL)
+
+Na etapa de backend v2, vamos introduzir PostgreSQL + migrações versionadas.
+
+Ferramentas recomendadas:
+- DBeaver
+- pgAdmin
+- DataGrip
+
+Comandos úteis no PostgreSQL:
+
+```bash
+psql "postgresql://usuario:senha@localhost:5432/mandabrain_v2"
+\dt
+```
+
+---
+
+Se quiser, no próximo passo eu já te entrego `docker-compose.yml` com MySQL (legado) + PostgreSQL (v2) para você visualizar os dois bancos em paralelo.

--- a/docs/INFRA_LOCAL.md
+++ b/docs/INFRA_LOCAL.md
@@ -1,0 +1,45 @@
+# Infra local paralela (legado + v2)
+
+Este ambiente sobe os dois bancos em paralelo para permitir validação e migração incremental:
+
+- MySQL 8 (legado): `localhost:3307`
+- PostgreSQL 16 (v2): `localhost:5432`
+
+## Subir ambiente
+
+```bash
+docker compose up -d
+```
+
+## Derrubar ambiente
+
+```bash
+docker compose down
+```
+
+## Derrubar removendo volumes
+
+```bash
+docker compose down -v
+```
+
+## Credenciais padrão
+
+### MySQL (legado)
+- Host: `localhost`
+- Porta: `3307`
+- Database: `mandabrain_legacy`
+- User: `mandabrain`
+- Password: `mandabrain`
+- Root password: `root_legacy`
+
+### PostgreSQL (v2)
+- Host: `localhost`
+- Porta: `5432`
+- Database: `mandabrain_v2`
+- User: `mandabrain`
+- Password: `mandabrain`
+
+## Próximo passo recomendado
+
+- Importar o dump legado no MySQL e começar mapeamento para o modelo PostgreSQL da v2.

--- a/docs/OPCOES_FRONTEND_UI.md
+++ b/docs/OPCOES_FRONTEND_UI.md
@@ -1,0 +1,28 @@
+# Opções para evoluir UI do MandaBrain v2
+
+## Opção 1 — CSS Modules + tokens (baixo risco)
+
+- **Como funciona:** manter Next.js puro e estilizar com CSS Modules e variáveis globais.
+- **Prós:** simples, sem dependências extras, ótimo para começar rápido.
+- **Contras:** pode exigir mais esforço manual em componentes complexos.
+- **Indicação:** boa para bootstrap inicial.
+
+## Opção 2 — Tailwind CSS + shadcn/ui (equilíbrio)
+
+- **Como funciona:** utilitários Tailwind + biblioteca de componentes copiáveis (shadcn).
+- **Prós:** produtividade alta, visual moderno, consistência entre telas.
+- **Contras:** curva de aprendizado e setup inicial maior.
+- **Indicação:** melhor custo-benefício para produto crescer com velocidade.
+
+## Opção 3 — Material UI (MUI) completo (enterprise)
+
+- **Como funciona:** biblioteca madura com muitos componentes prontos.
+- **Prós:** rapidez em telas administrativas e formulários.
+- **Contras:** bundle maior e customização visual pode ficar mais trabalhosa.
+- **Indicação:** útil se prioridade for painel administrativo robusto rapidamente.
+
+## Decisão registrada
+
+**Selecionada: Opção 2 (Tailwind CSS + shadcn/ui).**
+
+Aplicada no frontend v2 para iniciar as próximas features com base visual e componentes reutilizáveis.

--- a/docs/PLANO_MODERNIZACAO.md
+++ b/docs/PLANO_MODERNIZACAO.md
@@ -1,0 +1,150 @@
+# Plano de modernização do MandaBrain
+
+Este documento propõe uma evolução incremental do projeto original em PHP puro para uma arquitetura moderna, mantendo o sistema funcionando durante a migração.
+
+## 1) Diagnóstico atual (rápido)
+
+Pelos arquivos atuais, o projeto concentra:
+
+- Backend e views misturados no mesmo arquivo PHP.
+- SQL montado por concatenação de string em múltiplos pontos.
+- Login com `base64` (não é hashing seguro para senha).
+- Configuração de banco fixa no código-fonte.
+- Banco legado em MySQL/MyISAM com poucas restrições relacionais.
+
+## 2) Stack alvo recomendada
+
+### Backend
+
+- **Node.js + NestJS (TypeScript)**
+  - Organização em módulos e camadas.
+  - Validação forte com DTOs.
+  - Facilidade para API REST e evolução futura para microserviços.
+
+> Alternativa igualmente válida: Laravel 11 (PHP moderno), se você quiser manter ecossistema PHP.
+
+### Banco de dados
+
+- **PostgreSQL 16+**
+  - Integridade relacional forte.
+  - Bom suporte a índices, JSONB e migrações seguras.
+
+### ORM e migrações
+
+- **Prisma ORM** (se optar por NestJS)
+  - Schema versionado.
+  - Migrations previsíveis.
+
+### Frontend
+
+- **Next.js (React + TypeScript)**
+  - Excelente DX e componentização.
+  - SSR/SSG quando necessário.
+  - Fácil integração com API e autenticação moderna.
+
+### Autenticação
+
+- JWT com refresh token + rotação
+- Hash de senha com **Argon2id** ou **bcrypt**
+
+### Infra/DevOps
+
+- Docker + Docker Compose (dev)
+- GitHub Actions (lint, test, build)
+- Deploy inicial em Render/Railway/Fly.io/Vercel (front)
+
+## 3) Estratégia de migração (sem “big bang”)
+
+### Fase 0 — Preparação (1 semana)
+
+1. Definir domínio e funcionalidades essenciais (MVP).
+2. Criar repositório “v2” com backend + frontend + infra.
+3. Levantar modelo de dados alvo no PostgreSQL.
+
+### Fase 1 — Fundamentos (1 a 2 semanas)
+
+1. Subir API NestJS com módulos base:
+   - auth
+   - users
+   - courses
+   - classes (salas)
+   - files/uploads
+2. Configurar Prisma + migrações.
+3. Implementar autenticação segura (login, refresh, logout).
+
+### Fase 2 — Frontend novo (2 a 4 semanas)
+
+1. Criar layout e design system básico.
+2. Telas prioritárias:
+   - login/cadastro
+   - home aluno/professor
+   - listagem e detalhe de cursos
+   - administração básica
+3. Conectar frontend na nova API.
+
+### Fase 3 — Migração de dados (1 a 2 semanas)
+
+1. Exportar dados do MySQL legado.
+2. Criar script ETL para mapear tabelas para schema novo.
+3. Validar consistência (contagem, chaves e campos críticos).
+
+### Fase 4 — Cutover (1 semana)
+
+1. Rodar sistema antigo e novo em paralelo por alguns dias.
+2. Monitorar erros e ajustar.
+3. Virar tráfego oficialmente para o v2.
+
+## 4) Backlog técnico prioritário
+
+1. Segurança:
+   - trocar `base64` por hashing forte de senha;
+   - remover SQL concatenado e usar queries parametrizadas;
+   - adicionar rate-limit em login.
+2. Qualidade:
+   - testes unitários e de integração;
+   - lint/format automatizados;
+   - tratamento padronizado de erros.
+3. Produto:
+   - melhorar UX do fluxo de cadastro e administração;
+   - painéis por perfil (aluno, professor, admin).
+
+## 5) Roadmap sugerido (90 dias)
+
+- **Dias 1–15:** arquitetura, auth, usuários, CI/CD
+- **Dias 16–45:** cursos/salas/arquivos + frontend principal
+- **Dias 46–70:** migração de dados + validação
+- **Dias 71–90:** estabilização, observabilidade e go-live
+
+## 6) Primeiros passos práticos (esta semana)
+
+1. Congelar novas features no legado (somente correções críticas).
+2. Definir escopo do MVP v2 em uma página.
+3. Criar esquema inicial do banco no PostgreSQL.
+4. Iniciar API de autenticação e cadastro de usuários.
+5. Publicar protótipo de telas de login + dashboard.
+
+## 7) Estrutura de pastas sugerida (v2)
+
+```txt
+mandabrain-v2/
+  apps/
+    api/        # NestJS
+    web/        # Next.js
+  packages/
+    ui/         # componentes compartilhados
+    config/     # eslint/tsconfig/shared
+  infra/
+    docker/
+  docs/
+```
+
+## 8) Critérios de sucesso
+
+- Tempo de cadastro/login mais rápido e com menos falhas.
+- Redução de erros críticos de segurança.
+- Base de código com testes e padrão de arquitetura.
+- Deploy reproduzível com CI/CD.
+
+---
+
+Se você quiser, o próximo passo é eu abrir um **plano técnico detalhado por feature** (auth, usuários, cursos, salas, arquivos), incluindo modelo de dados inicial e endpoints da API para começar a codar.

--- a/mandabrain-v2/README.md
+++ b/mandabrain-v2/README.md
@@ -1,0 +1,44 @@
+# MandaBrain v2 (frontend)
+
+Migração incremental do frontend legado para Next.js, mantendo o PHP atual intacto.
+
+## Stack desta fase
+
+- Next.js 14 + TypeScript
+- Tailwind CSS + componentes no padrão shadcn/ui
+- Vitest para testes unitários
+- Sessão assinada em cookie `httpOnly`
+
+## Execução local
+
+```bash
+cd mandabrain-v2/apps/web
+cp .env.example .env.local
+npm install
+npm run test
+npm run dev
+```
+
+## Sessão assinada
+
+- Variável obrigatória: `SESSION_SECRET`
+- Recomendação: segredo com 32+ caracteres
+- Cookie: `mb_session` (`httpOnly`, `sameSite=lax`)
+
+## Fluxos implementados
+
+- `GET /api/health`
+- `GET /login`
+- `POST /api/auth/login`
+- `GET /api/auth/me`
+- `POST /api/auth/refresh`
+- `POST /api/auth/logout`
+- `GET /dashboard` (protegida)
+- `GET /cursos` (protegida, mock)
+- `GET /cursos/[slug]` (protegida, mock)
+
+## Objetivo da etapa atual
+
+- Validar navegação e estrutura de produto com dados mock.
+- Padronizar UI para acelerar próximas features.
+- Manter evolução coberta por testes em cada etapa.

--- a/mandabrain-v2/apps/web/.env.example
+++ b/mandabrain-v2/apps/web/.env.example
@@ -1,0 +1,2 @@
+# Use um segredo forte (32+ caracteres) para assinar sessões.
+SESSION_SECRET=troque-este-segredo-super-longo-em-producao-12345

--- a/mandabrain-v2/apps/web/components.json
+++ b/mandabrain-v2/apps/web/components.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": false,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/mandabrain-v2/apps/web/middleware.ts
+++ b/mandabrain-v2/apps/web/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { SESSION_COOKIE_NAME } from '@/features/auth/session';
+
+const PROTECTED_PATHS = ['/dashboard', '/cursos'];
+
+export function middleware(request: NextRequest) {
+  const isProtected = PROTECTED_PATHS.some((path) => request.nextUrl.pathname.startsWith(path));
+
+  if (!isProtected) {
+    return NextResponse.next();
+  }
+
+  const token = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+
+  if (!token) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('from', request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/cursos/:path*']
+};

--- a/mandabrain-v2/apps/web/next-env.d.ts
+++ b/mandabrain-v2/apps/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/mandabrain-v2/apps/web/next.config.mjs
+++ b/mandabrain-v2/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/mandabrain-v2/apps/web/package.json
+++ b/mandabrain-v2/apps/web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@mandabrain/web",
+  "version": "0.3.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next": "^14.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
+  }
+}

--- a/mandabrain-v2/apps/web/postcss.config.mjs
+++ b/mandabrain-v2/apps/web/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/mandabrain-v2/apps/web/src/app/api/auth/login/route.ts
+++ b/mandabrain-v2/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { createSessionToken, SESSION_COOKIE_NAME } from '@/features/auth/session';
+import { validateLoginInput } from '@/features/auth/validation';
+import type { AuthUser, LoginInput, LoginSuccess, UserRole } from '@/features/auth/types';
+
+function inferRole(email: string): UserRole {
+  if (email.includes('admin')) return 'admin';
+  if (email.includes('prof')) return 'teacher';
+  return 'student';
+}
+
+export function buildLoginSuccess(email: string): LoginSuccess {
+  const user: AuthUser = {
+    id: 1,
+    name: email.split('@')[0] || 'Usuário',
+    role: inferRole(email)
+  };
+
+  return { user };
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as LoginInput;
+  const errors = validateLoginInput(body);
+
+  if (errors.length > 0) {
+    return NextResponse.json({ error: errors[0] }, { status: 400 });
+  }
+
+  try {
+    const payload = buildLoginSuccess(body.email);
+    const response = NextResponse.json(payload, { status: 200 });
+
+    response.cookies.set({
+      name: SESSION_COOKIE_NAME,
+      value: createSessionToken(payload.user),
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 12
+    });
+
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Falha de configuração da sessão. Verifique SESSION_SECRET.'
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/mandabrain-v2/apps/web/src/app/api/auth/logout/route.ts
+++ b/mandabrain-v2/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { SESSION_COOKIE_NAME } from '@/features/auth/session';
+
+export async function POST() {
+  const response = NextResponse.json({ success: true }, { status: 200 });
+
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: '',
+    path: '/',
+    maxAge: 0,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production'
+  });
+
+  return response;
+}

--- a/mandabrain-v2/apps/web/src/app/api/auth/me/route.ts
+++ b/mandabrain-v2/apps/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { parseSessionToken, SESSION_COOKIE_NAME } from '@/features/auth/session';
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Não autenticado.' }, { status: 401 });
+  }
+
+  const user = parseSessionToken(token);
+
+  if (!user) {
+    return NextResponse.json({ error: 'Sessão inválida.' }, { status: 401 });
+  }
+
+  return NextResponse.json({ user }, { status: 200 });
+}

--- a/mandabrain-v2/apps/web/src/app/api/auth/refresh/route.ts
+++ b/mandabrain-v2/apps/web/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,44 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { createSessionToken, parseSessionToken, SESSION_COOKIE_NAME } from '@/features/auth/session';
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Não autenticado.' }, { status: 401 });
+  }
+
+  const user = parseSessionToken(token);
+
+  if (!user) {
+    return NextResponse.json({ error: 'Sessão inválida.' }, { status: 401 });
+  }
+
+  try {
+    const response = NextResponse.json({ user, refreshed: true }, { status: 200 });
+
+    response.cookies.set({
+      name: SESSION_COOKIE_NAME,
+      value: createSessionToken(user),
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 12
+    });
+
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Falha de configuração da sessão. Verifique SESSION_SECRET.'
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/mandabrain-v2/apps/web/src/app/api/health/route.ts
+++ b/mandabrain-v2/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getSystemStatus } from '@/lib/status';
+
+export async function GET() {
+  return NextResponse.json(getSystemStatus());
+}

--- a/mandabrain-v2/apps/web/src/app/cursos/[slug]/page.tsx
+++ b/mandabrain-v2/apps/web/src/app/cursos/[slug]/page.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { getSessionUser } from '@/features/auth/get-session-user';
+import { getCourseBySlug, getCourseProgress } from '@/features/courses/mock-data';
+
+type CourseDetailsPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function CourseDetailsPage({ params }: CourseDetailsPageProps) {
+  const user = await getSessionUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { slug } = await params;
+  const course = getCourseBySlug(slug);
+
+  if (!course) {
+    notFound();
+  }
+
+  const progress = getCourseProgress(course);
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <Card>
+        <CardHeader className="gap-3">
+          <p className="text-sm text-slate-500">
+            <Link href="/dashboard">Dashboard</Link> / <Link href="/cursos">Cursos</Link> /{' '}
+            <strong>{course.title}</strong>
+          </p>
+          <CardTitle>{course.title}</CardTitle>
+          <CardDescription>{course.summary}</CardDescription>
+          <div className="flex flex-wrap gap-2">
+            <Badge>Nível: {course.level}</Badge>
+            <Badge variant="outline">Instrutor: {course.instructor}</Badge>
+            <Badge variant="outline">Perfil: {user.role}</Badge>
+          </div>
+        </CardHeader>
+
+        <CardContent className="grid gap-6">
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between text-sm text-slate-600">
+              <span>Conclusão</span>
+              <strong>{progress.percent}%</strong>
+            </div>
+            <Progress value={progress.percent} />
+          </div>
+
+          <section className="grid gap-3">
+            <h2 className="text-xl font-semibold text-slate-900">Aulas</h2>
+            <ul className="grid gap-2">
+              {course.lessons.map((lesson) => (
+                <li
+                  key={lesson.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 p-3"
+                >
+                  <div>
+                    <strong className="block text-slate-800">{lesson.title}</strong>
+                    <p className="text-sm text-slate-500">{lesson.durationMinutes} min</p>
+                  </div>
+                  <Badge variant={lesson.completed ? 'success' : 'warning'}>
+                    {lesson.completed ? 'Concluída' : 'Pendente'}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <Link href="/cursos" className="no-underline hover:no-underline">
+            <Button variant="ghost">Voltar ao catálogo</Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/mandabrain-v2/apps/web/src/app/cursos/page.tsx
+++ b/mandabrain-v2/apps/web/src/app/cursos/page.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { getSessionUser } from '@/features/auth/get-session-user';
+import { getCourseProgress, getLearningSummary, listCourses } from '@/features/courses/mock-data';
+
+export default async function CoursesPage() {
+  const user = await getSessionUser();
+
+  if (!user) {
+    redirect('/login?from=/cursos');
+  }
+
+  const courses = listCourses();
+  const summary = getLearningSummary();
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <Card>
+        <CardHeader className="gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle>Catálogo de cursos (mock)</CardTitle>
+            <Link href="/dashboard" className="no-underline hover:no-underline">
+              <Button variant="ghost" size="sm">
+                Voltar ao dashboard
+              </Button>
+            </Link>
+          </div>
+          <CardDescription>
+            Olá, <strong>{user.name}</strong>. Nesta fase usamos dados mock para acelerar a montagem
+            de features sem bloquear o fluxo de produto.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="grid gap-6">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <SummaryItem label="Cursos no catálogo" value={`${summary.totalCourses}`} />
+            <SummaryItem label="Cursos concluídos" value={`${summary.completedCourses}`} />
+            <SummaryItem label="Progresso geral" value={`${summary.percent}%`} />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {courses.map((course) => {
+              const progress = getCourseProgress(course);
+
+              return (
+                <article key={course.id} className="grid gap-4 rounded-xl border border-slate-200 p-4">
+                  <div className="grid gap-1">
+                    <h2 className="text-lg font-semibold text-slate-900">{course.title}</h2>
+                    <p className="text-sm text-slate-600">{course.summary}</p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Badge>{course.level}</Badge>
+                    <Badge variant="outline">{course.instructor}</Badge>
+                  </div>
+
+                  <div className="grid gap-2">
+                    <div className="flex items-center justify-between text-sm text-slate-600">
+                      <span>Progresso</span>
+                      <strong>
+                        {progress.completedLessons}/{progress.totalLessons}
+                      </strong>
+                    </div>
+                    <Progress value={progress.percent} />
+                  </div>
+
+                  <Link href={`/cursos/${course.slug}`} className="no-underline hover:no-underline">
+                    <Button className="w-full">Ver curso</Button>
+                  </Link>
+                </article>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+type SummaryItemProps = {
+  label: string;
+  value: string;
+};
+
+function SummaryItem({ label, value }: SummaryItemProps) {
+  return (
+    <article className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <span className="block text-sm text-slate-500">{label}</span>
+      <strong className="mt-1 block text-2xl text-slate-800">{value}</strong>
+    </article>
+  );
+}

--- a/mandabrain-v2/apps/web/src/app/dashboard/page.tsx
+++ b/mandabrain-v2/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { LogoutButton } from '@/components/logout-button';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getSessionUser } from '@/features/auth/get-session-user';
+import { getLearningSummary } from '@/features/courses/mock-data';
+
+export default async function DashboardPage() {
+  const user = await getSessionUser();
+
+  if (!user) {
+    redirect('/login?from=/dashboard');
+  }
+
+  const summary = getLearningSummary();
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Dashboard</CardTitle>
+          <CardDescription>
+            Sessão ativa para <strong>{user.name}</strong>.
+          </CardDescription>
+          <div className="pt-2">
+            <Badge variant="outline">Perfil: {user.role}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-6">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <StatCard label="Cursos disponíveis" value={`${summary.totalCourses}`} />
+            <StatCard label="Aulas concluídas" value={`${summary.completedLessons}/${summary.totalLessons}`} />
+            <StatCard label="Progresso geral" value={`${summary.percent}%`} />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Link href="/cursos" className="no-underline hover:no-underline">
+              <Button>Explorar cursos</Button>
+            </Link>
+            <Link href="/" className="no-underline hover:no-underline">
+              <Button variant="ghost">Voltar para home</Button>
+            </Link>
+          </div>
+
+          <LogoutButton />
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+type StatCardProps = {
+  label: string;
+  value: string;
+};
+
+function StatCard({ label, value }: StatCardProps) {
+  return (
+    <article className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <span className="block text-sm text-slate-500">{label}</span>
+      <strong className="mt-1 block text-2xl text-slate-800">{value}</strong>
+    </article>
+  );
+}

--- a/mandabrain-v2/apps/web/src/app/globals.css
+++ b/mandabrain-v2/apps/web/src/app/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html,
+  body {
+    @apply min-h-screen bg-slate-50 text-slate-800 antialiased;
+  }
+
+  body {
+    background-image: radial-gradient(circle at top, #eef4ff, #f8fafc 45%);
+  }
+
+  a {
+    @apply text-blue-600 hover:underline;
+  }
+}

--- a/mandabrain-v2/apps/web/src/app/icon.svg
+++ b/mandabrain-v2/apps/web/src/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="MandaBrain">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)"/>
+  <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" font-size="30" font-family="Arial, sans-serif" fill="#fff">M</text>
+</svg>

--- a/mandabrain-v2/apps/web/src/app/layout.tsx
+++ b/mandabrain-v2/apps/web/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'MandaBrain v2',
+  description: 'Nova base do MandaBrain usando Next.js + TypeScript.'
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="pt-BR">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/mandabrain-v2/apps/web/src/app/login/page.tsx
+++ b/mandabrain-v2/apps/web/src/app/login/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { LoginForm } from '@/components/login-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+type LoginPageProps = {
+  searchParams: Promise<{
+    from?: string;
+  }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const { from } = await searchParams;
+
+  return (
+    <main className="mx-auto max-w-xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Login (v2)</CardTitle>
+          <CardDescription>
+            Fluxo inicial de autenticação para evoluir as features mantendo segurança básica de
+            sessão.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <LoginForm redirectTo={from || '/dashboard'} />
+          <p className="text-sm text-slate-600">
+            <Link href="/">← Voltar para home</Link>
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/mandabrain-v2/apps/web/src/app/page.tsx
+++ b/mandabrain-v2/apps/web/src/app/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>MandaBrain v2</CardTitle>
+          <CardDescription>
+            Base moderna do frontend em Next.js + Tailwind + componentes no padrão shadcn/ui.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-5">
+          <ul className="list-disc space-y-2 pl-5 text-sm text-slate-700">
+            <li>✅ Sessão assinada em cookie httpOnly e proteção de rota.</li>
+            <li>✅ Testes automatizados com Vitest para auth e regras de sessão.</li>
+            <li>✅ Catálogo de cursos + detalhe + progresso com dados mock.</li>
+            <li>✅ Estrutura visual preparada para escalar features com consistência.</li>
+          </ul>
+
+          <div className="flex flex-wrap gap-3">
+            <Link href="/login" className="no-underline hover:no-underline">
+              <Button>Entrar</Button>
+            </Link>
+            <Link href="/cursos" className="no-underline hover:no-underline">
+              <Button variant="ghost">Ver catálogo mock</Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/mandabrain-v2/apps/web/src/components/login-form.tsx
+++ b/mandabrain-v2/apps/web/src/components/login-form.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { login } from '@/features/auth/service';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+type LoginFormProps = {
+  redirectTo?: string;
+};
+
+export function LoginForm({ redirectTo = '/dashboard' }: LoginFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+
+    try {
+      const result = await login({ email, password });
+      setSuccess(`Login OK: ${result.user.name} (${result.user.role})`);
+      router.push(redirectTo);
+      router.refresh();
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Erro inesperado.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="grid gap-4">
+      <label className="grid gap-2 text-sm font-medium text-slate-700">
+        E-mail
+        <Input
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="voce@email.com"
+          required
+        />
+      </label>
+
+      <label className="grid gap-2 text-sm font-medium text-slate-700">
+        Senha
+        <Input
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          placeholder="mínimo 8 caracteres"
+          required
+        />
+      </label>
+
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Entrando...' : 'Entrar'}
+      </Button>
+
+      {error ? <p className="text-sm font-medium text-red-700">{error}</p> : null}
+      {success ? <p className="text-sm font-medium text-emerald-700">{success}</p> : null}
+    </form>
+  );
+}

--- a/mandabrain-v2/apps/web/src/components/logout-button.tsx
+++ b/mandabrain-v2/apps/web/src/components/logout-button.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { logout, refreshSession } from '@/features/auth/service';
+import { Button } from '@/components/ui/button';
+
+export function LogoutButton() {
+  const router = useRouter();
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleRefresh() {
+    const user = await refreshSession();
+    setStatus(user ? `Sessão renovada para ${user.name}.` : 'Não foi possível renovar a sessão.');
+    router.refresh();
+  }
+
+  async function handleLogout() {
+    await logout();
+    router.push('/login');
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button type="button" onClick={handleRefresh}>
+        Renovar sessão
+      </Button>
+      <Button type="button" variant="secondary" onClick={handleLogout}>
+        Sair
+      </Button>
+      {status ? <small className="text-sm text-slate-600">{status}</small> : null}
+    </div>
+  );
+}

--- a/mandabrain-v2/apps/web/src/components/ui/badge.tsx
+++ b/mandabrain-v2/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-indigo-100 text-indigo-700',
+        success: 'border-transparent bg-emerald-100 text-emerald-700',
+        warning: 'border-transparent bg-amber-100 text-amber-700',
+        outline: 'border-slate-200 text-slate-700'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/mandabrain-v2/apps/web/src/components/ui/button.tsx
+++ b/mandabrain-v2/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-700',
+        secondary: 'bg-slate-900 text-white hover:bg-slate-800',
+        ghost: 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100',
+        outline: 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/mandabrain-v2/apps/web/src/components/ui/card.tsx
+++ b/mandabrain-v2/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-2xl border border-slate-200 bg-white shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-slate-500', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+);
+CardContent.displayName = 'CardContent';
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/mandabrain-v2/apps/web/src/components/ui/input.tsx
+++ b/mandabrain-v2/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(({ className, ...props }, ref) => {
+  return (
+    <input
+      className={cn(
+        'flex h-10 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/mandabrain-v2/apps/web/src/components/ui/progress.tsx
+++ b/mandabrain-v2/apps/web/src/components/ui/progress.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib/utils';
+
+type ProgressProps = {
+  value: number;
+  className?: string;
+};
+
+export function clampProgress(value: number) {
+  return Math.min(100, Math.max(0, value));
+}
+
+export function Progress({ value, className }: ProgressProps) {
+  const safeValue = clampProgress(value);
+
+  return (
+    <div className={cn('relative h-2 w-full overflow-hidden rounded-full bg-slate-200', className)}>
+      <div className="h-full bg-gradient-to-r from-blue-500 to-indigo-500" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}

--- a/mandabrain-v2/apps/web/src/features/auth/get-session-user.ts
+++ b/mandabrain-v2/apps/web/src/features/auth/get-session-user.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers';
+import { parseSessionToken, SESSION_COOKIE_NAME } from './session';
+
+export async function getSessionUser() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+  return token ? parseSessionToken(token) : null;
+}

--- a/mandabrain-v2/apps/web/src/features/auth/service.ts
+++ b/mandabrain-v2/apps/web/src/features/auth/service.ts
@@ -1,0 +1,53 @@
+import type { AuthUser, LoginError, LoginInput, LoginSuccess } from './types';
+
+export async function login(input: LoginInput): Promise<LoginSuccess> {
+  const response = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(input)
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as LoginError;
+    throw new Error(error.error ?? 'Falha ao autenticar.');
+  }
+
+  return (await response.json()) as LoginSuccess;
+}
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
+  const response = await fetch('/api/auth/me', {
+    method: 'GET',
+    credentials: 'include'
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as { user: AuthUser };
+  return payload.user;
+}
+
+export async function refreshSession(): Promise<AuthUser | null> {
+  const response = await fetch('/api/auth/refresh', {
+    method: 'POST',
+    credentials: 'include'
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as { user: AuthUser };
+  return payload.user;
+}
+
+export async function logout(): Promise<void> {
+  await fetch('/api/auth/logout', {
+    method: 'POST',
+    credentials: 'include'
+  });
+}

--- a/mandabrain-v2/apps/web/src/features/auth/session.ts
+++ b/mandabrain-v2/apps/web/src/features/auth/session.ts
@@ -1,0 +1,84 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { LoginSuccess } from './types';
+
+export const SESSION_COOKIE_NAME = 'mb_session';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 12;
+const MIN_SECRET_LENGTH = 32;
+
+export type SessionUser = LoginSuccess['user'];
+
+type SessionPayload = {
+  user: SessionUser;
+  exp: number;
+};
+
+type CreateTokenOptions = {
+  ttlSeconds?: number;
+  nowMs?: number;
+};
+
+function getSessionSecret(): string {
+  const secret = process.env.SESSION_SECRET;
+
+  if (!secret || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `SESSION_SECRET inválido. Defina um segredo com pelo menos ${MIN_SECRET_LENGTH} caracteres.`
+    );
+  }
+
+  return secret;
+}
+
+function sign(value: string): string {
+  return createHmac('sha256', getSessionSecret()).update(value).digest('base64url');
+}
+
+export function createSessionToken(user: SessionUser, options: CreateTokenOptions = {}): string {
+  const now = options.nowMs ?? Date.now();
+  const ttl = options.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+
+  const payload: SessionPayload = {
+    user,
+    exp: Math.floor(now / 1000) + ttl
+  };
+
+  const payloadEncoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+  const signature = sign(payloadEncoded);
+  return `${payloadEncoded}.${signature}`;
+}
+
+export function parseSessionToken(token: string, nowMs = Date.now()): SessionUser | null {
+  try {
+    const [payloadEncoded, signature] = token.split('.');
+
+    if (!payloadEncoded || !signature) {
+      return null;
+    }
+
+    const expectedSignature = sign(payloadEncoded);
+    const signatureMatches = timingSafeEqual(
+      Buffer.from(signature, 'utf-8'),
+      Buffer.from(expectedSignature, 'utf-8')
+    );
+
+    if (!signatureMatches) {
+      return null;
+    }
+
+    const json = Buffer.from(payloadEncoded, 'base64url').toString('utf-8');
+    const payload = JSON.parse(json) as SessionPayload;
+
+    if (!payload.user?.id || !payload.user?.name || !payload.user?.role || !payload.exp) {
+      return null;
+    }
+
+    const nowSeconds = Math.floor(nowMs / 1000);
+    if (payload.exp <= nowSeconds) {
+      return null;
+    }
+
+    return payload.user;
+  } catch {
+    return null;
+  }
+}

--- a/mandabrain-v2/apps/web/src/features/auth/types.ts
+++ b/mandabrain-v2/apps/web/src/features/auth/types.ts
@@ -1,0 +1,20 @@
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type UserRole = 'student' | 'teacher' | 'admin';
+
+export type AuthUser = {
+  id: number;
+  name: string;
+  role: UserRole;
+};
+
+export type LoginSuccess = {
+  user: AuthUser;
+};
+
+export type LoginError = {
+  error: string;
+};

--- a/mandabrain-v2/apps/web/src/features/auth/validation.ts
+++ b/mandabrain-v2/apps/web/src/features/auth/validation.ts
@@ -1,0 +1,21 @@
+import type { LoginInput } from './types';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateLoginInput(input: LoginInput): string[] {
+  const errors: string[] = [];
+
+  if (!input.email?.trim()) {
+    errors.push('E-mail é obrigatório.');
+  } else if (!EMAIL_REGEX.test(input.email)) {
+    errors.push('E-mail inválido.');
+  }
+
+  if (!input.password?.trim()) {
+    errors.push('Senha é obrigatória.');
+  } else if (input.password.length < 8) {
+    errors.push('Senha deve ter pelo menos 8 caracteres.');
+  }
+
+  return errors;
+}

--- a/mandabrain-v2/apps/web/src/features/courses/mock-data.ts
+++ b/mandabrain-v2/apps/web/src/features/courses/mock-data.ts
@@ -1,0 +1,84 @@
+import type { Course, CourseProgress } from './types';
+
+const MOCK_COURSES: Course[] = [
+  {
+    id: 'c1',
+    slug: 'nextjs-fundamentos',
+    title: 'Next.js Fundamentos',
+    summary: 'App Router, Server Components e integração com APIs internas.',
+    instructor: 'Julia Mendes',
+    level: 'iniciante',
+    tags: ['nextjs', 'frontend', 'react'],
+    lessons: [
+      { id: 'l1', title: 'Visão geral do App Router', durationMinutes: 18, completed: true },
+      { id: 'l2', title: 'Layouts e páginas', durationMinutes: 24, completed: true },
+      { id: 'l3', title: 'Rotas de API no Next', durationMinutes: 27, completed: false }
+    ]
+  },
+  {
+    id: 'c2',
+    slug: 'typescript-na-pratica',
+    title: 'TypeScript na Prática',
+    summary: 'Tipos utilitários, narrowing e organização de módulos para projetos reais.',
+    instructor: 'Marcos Lima',
+    level: 'intermediario',
+    tags: ['typescript', 'arquitetura'],
+    lessons: [
+      { id: 'l1', title: 'Modelagem de tipos de domínio', durationMinutes: 21, completed: true },
+      { id: 'l2', title: 'Narrowing e guards', durationMinutes: 19, completed: false },
+      { id: 'l3', title: 'Estratégias de refactor com segurança', durationMinutes: 31, completed: false }
+    ]
+  },
+  {
+    id: 'c3',
+    slug: 'testes-com-vitest',
+    title: 'Testes com Vitest',
+    summary: 'Como criar testes rápidos para regras de negócio e rotas de API.',
+    instructor: 'Ana Costa',
+    level: 'iniciante',
+    tags: ['testes', 'vitest'],
+    lessons: [
+      { id: 'l1', title: 'Primeiro teste unitário', durationMinutes: 14, completed: true },
+      { id: 'l2', title: 'Organizando suites por feature', durationMinutes: 22, completed: true },
+      { id: 'l3', title: 'Testando API routes', durationMinutes: 26, completed: true }
+    ]
+  }
+];
+
+export function listCourses(): Course[] {
+  return MOCK_COURSES;
+}
+
+export function getCourseBySlug(slug: string): Course | null {
+  return MOCK_COURSES.find((course) => course.slug === slug) ?? null;
+}
+
+export function getCourseProgress(course: Course): CourseProgress {
+  const totalLessons = course.lessons.length;
+  const completedLessons = course.lessons.filter((lesson) => lesson.completed).length;
+
+  return {
+    completedLessons,
+    totalLessons,
+    percent: totalLessons === 0 ? 0 : Math.round((completedLessons / totalLessons) * 100)
+  };
+}
+
+export function getLearningSummary() {
+  const courses = listCourses();
+  const totalCourses = courses.length;
+  const completedCourses = courses.filter((course) => getCourseProgress(course).percent === 100).length;
+  const totalLessons = courses.reduce((total, course) => total + course.lessons.length, 0);
+  const completedLessons = courses.reduce(
+    (total, course) => total + getCourseProgress(course).completedLessons,
+    0
+  );
+
+  return {
+    totalCourses,
+    completedCourses,
+    totalLessons,
+    completedLessons,
+    percent: totalLessons === 0 ? 0 : Math.round((completedLessons / totalLessons) * 100)
+  };
+}

--- a/mandabrain-v2/apps/web/src/features/courses/types.ts
+++ b/mandabrain-v2/apps/web/src/features/courses/types.ts
@@ -1,0 +1,25 @@
+export type CourseLevel = 'iniciante' | 'intermediario' | 'avancado';
+
+export type CourseLesson = {
+  id: string;
+  title: string;
+  durationMinutes: number;
+  completed: boolean;
+};
+
+export type Course = {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  instructor: string;
+  level: CourseLevel;
+  tags: string[];
+  lessons: CourseLesson[];
+};
+
+export type CourseProgress = {
+  completedLessons: number;
+  totalLessons: number;
+  percent: number;
+};

--- a/mandabrain-v2/apps/web/src/lib/status.ts
+++ b/mandabrain-v2/apps/web/src/lib/status.ts
@@ -1,0 +1,15 @@
+export type SystemStatus = {
+  service: 'mandabrain-web';
+  status: 'ok';
+  timestamp: string;
+  version: string;
+};
+
+export function getSystemStatus(version = 'v2-bootstrap'): SystemStatus {
+  return {
+    service: 'mandabrain-web',
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    version
+  };
+}

--- a/mandabrain-v2/apps/web/src/lib/utils.ts
+++ b/mandabrain-v2/apps/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/mandabrain-v2/apps/web/tailwind.config.ts
+++ b/mandabrain-v2/apps/web/tailwind.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#f4f7fb',
+        foreground: '#1f2937',
+        card: '#ffffff',
+        primary: {
+          DEFAULT: '#2563eb',
+          foreground: '#ffffff'
+        },
+        muted: {
+          DEFAULT: '#f1f5f9',
+          foreground: '#64748b'
+        },
+        border: '#d1d5db'
+      },
+      borderRadius: {
+        lg: '0.75rem',
+        md: '0.625rem',
+        sm: '0.5rem'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/mandabrain-v2/apps/web/tests/auth/login-route.test.ts
+++ b/mandabrain-v2/apps/web/tests/auth/login-route.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildLoginSuccess } from '../../src/app/api/auth/login/route';
+
+describe('buildLoginSuccess', () => {
+  it('retorna role admin quando email contém admin', () => {
+    const result = buildLoginSuccess('admin@mandabrain.com');
+
+    expect(result.user.role).toBe('admin');
+  });
+
+  it('retorna role student para usuário comum', () => {
+    const result = buildLoginSuccess('aluno@mandabrain.com');
+
+    expect(result.user.role).toBe('student');
+    expect(result.user.name).toBe('aluno');
+  });
+
+  it('retorna role teacher quando email contém prof', () => {
+    const result = buildLoginSuccess('prof.julia@mandabrain.com');
+
+    expect(result.user.role).toBe('teacher');
+  });
+});

--- a/mandabrain-v2/apps/web/tests/auth/session.test.ts
+++ b/mandabrain-v2/apps/web/tests/auth/session.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createSessionToken, parseSessionToken } from '../../src/features/auth/session';
+
+const ORIGINAL_SECRET = process.env.SESSION_SECRET;
+
+beforeEach(() => {
+  process.env.SESSION_SECRET = 'test-secret-com-mais-de-32-caracteres-123';
+});
+
+afterEach(() => {
+  process.env.SESSION_SECRET = ORIGINAL_SECRET;
+});
+
+describe('session token (signed)', () => {
+  it('serializa e desserializa usuário da sessão com assinatura válida', () => {
+    const token = createSessionToken({ id: 10, name: 'aluno', role: 'student' }, { nowMs: 1_000 });
+    const parsed = parseSessionToken(token, 2_000);
+
+    expect(parsed).toEqual({ id: 10, name: 'aluno', role: 'student' });
+  });
+
+  it('retorna null quando payload é adulterado', () => {
+    const token = createSessionToken({ id: 10, name: 'aluno', role: 'student' });
+    const [payload, signature] = token.split('.');
+    const tamperedPayload = `${payload}x`;
+    const tampered = `${tamperedPayload}.${signature}`;
+
+    expect(parseSessionToken(tampered)).toBeNull();
+  });
+
+  it('retorna null para token expirado', () => {
+    const token = createSessionToken(
+      { id: 10, name: 'aluno', role: 'student' },
+      { ttlSeconds: 1, nowMs: 1_000 }
+    );
+
+    expect(parseSessionToken(token, 3_000)).toBeNull();
+  });
+
+  it('lança erro quando SESSION_SECRET está ausente', () => {
+    delete process.env.SESSION_SECRET;
+
+    expect(() =>
+      createSessionToken({ id: 10, name: 'aluno', role: 'student' }, { nowMs: 1_000 })
+    ).toThrow('SESSION_SECRET inválido');
+  });
+});

--- a/mandabrain-v2/apps/web/tests/auth/validation.test.ts
+++ b/mandabrain-v2/apps/web/tests/auth/validation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { validateLoginInput } from '../../src/features/auth/validation';
+
+describe('validateLoginInput', () => {
+  it('retorna erros para payload inválido', () => {
+    const result = validateLoginInput({ email: 'abc', password: '123' });
+
+    expect(result).toContain('E-mail inválido.');
+    expect(result).toContain('Senha deve ter pelo menos 8 caracteres.');
+  });
+
+  it('não retorna erros para payload válido', () => {
+    const result = validateLoginInput({ email: 'aluno@mandabrain.com', password: '12345678' });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/mandabrain-v2/apps/web/tests/courses/mock-data.test.ts
+++ b/mandabrain-v2/apps/web/tests/courses/mock-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCourseBySlug,
+  getCourseProgress,
+  getLearningSummary,
+  listCourses
+} from '../../src/features/courses/mock-data';
+
+describe('courses mock data', () => {
+  it('lista cursos disponíveis', () => {
+    const courses = listCourses();
+
+    expect(courses.length).toBeGreaterThan(0);
+    expect(courses[0]?.slug).toBeDefined();
+  });
+
+  it('retorna curso por slug quando existir', () => {
+    const course = getCourseBySlug('nextjs-fundamentos');
+
+    expect(course).not.toBeNull();
+    expect(course?.title).toContain('Next.js');
+  });
+
+  it('calcula progresso de curso e resumo geral', () => {
+    const course = getCourseBySlug('testes-com-vitest');
+    expect(course).not.toBeNull();
+
+    const progress = getCourseProgress(course!);
+    const summary = getLearningSummary();
+
+    expect(progress.percent).toBe(100);
+    expect(summary.totalCourses).toBe(3);
+    expect(summary.totalLessons).toBeGreaterThanOrEqual(summary.completedLessons);
+  });
+});

--- a/mandabrain-v2/apps/web/tests/status.test.ts
+++ b/mandabrain-v2/apps/web/tests/status.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { getSystemStatus } from '../src/lib/status';
+
+describe('getSystemStatus', () => {
+  it('retorna payload base de health-check', () => {
+    const result = getSystemStatus('test-version');
+
+    expect(result.service).toBe('mandabrain-web');
+    expect(result.status).toBe('ok');
+    expect(result.version).toBe('test-version');
+    expect(new Date(result.timestamp).toString()).not.toBe('Invalid Date');
+  });
+});

--- a/mandabrain-v2/apps/web/tests/ui/progress.test.ts
+++ b/mandabrain-v2/apps/web/tests/ui/progress.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { clampProgress } from '../../src/components/ui/progress';
+
+describe('clampProgress', () => {
+  it('limita valores abaixo de 0 para 0', () => {
+    expect(clampProgress(-15)).toBe(0);
+  });
+
+  it('limita valores acima de 100 para 100', () => {
+    expect(clampProgress(185)).toBe(100);
+  });
+
+  it('mantém valores válidos', () => {
+    expect(clampProgress(67)).toBe(67);
+  });
+});

--- a/mandabrain-v2/apps/web/tests/ui/utils.test.ts
+++ b/mandabrain-v2/apps/web/tests/ui/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../../src/lib/utils';
+
+describe('cn', () => {
+  it('mescla classes corretamente', () => {
+    expect(cn('p-2', 'text-sm')).toBe('p-2 text-sm');
+  });
+
+  it('resolve conflitos tailwind mantendo a última regra', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+  });
+});

--- a/mandabrain-v2/apps/web/tsconfig.json
+++ b/mandabrain-v2/apps/web/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/mandabrain-v2/apps/web/vitest.config.ts
+++ b/mandabrain-v2/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
### Motivation

- Criar a base do frontend v2 em Next.js + TypeScript/Tailwind para migração incremental do produto.
- Fornecer um fluxo inicial de autenticação por sessão (cookie assinado) e proteção de rotas para validar UX e segurança mínima.
- Incluir documentação, infra local (Docker Compose) e pipeline de CI para acelerar desenvolvimento e validação contínua.

### Description

- Adiciona a nova app `mandabrain-v2/apps/web` com layout, páginas (home, login, dashboard, cursos, curso detalhe), assets e configuração Next.js/Tailwind/TypeScript.
- Implementa API routes de autenticação (`/api/auth/*`) e utilitários de sessão assinada em `src/features/auth` com criação/validação de token HMAC e validação de input.
- Inclui um conjunto de componentes UI reutilizáveis (`ui/*`), utilitários (`lib/*`), dados mock para cursos e botões/forms cliente que consomem as rotas de auth.
- Adiciona docs (`docs/*`), `docker-compose.yml` para MySQL legado + PostgreSQL v2, `.gitignore`, `README` e `env.example` para facilitar execução local.
- Configura testes com Vitest (`vitest.config.ts`), adiciona várias suites de teste unitário em `tests/**` e cria workflow GitHub Actions `web-ci` que executa `npm run test` em `mandabrain-v2/apps/web`.

### Testing

- Foram adicionados testes unitários com Vitest cobrindo validação de login, criação/parse de token de sessão, utilitários de UI e dados mock de cursos; os arquivos estão em `mandabrain-v2/apps/web/tests/`.
- Configurado `vitest.config.ts` e o script de teste `test` em `package.json` para executar as suites com `vitest run`.
- Pipeline de CI `web-ci` roda `npm install` e `npm run test` no diretório `mandabrain-v2/apps/web`, porém não houve execução automática do workflow dentro deste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a24d489c8321aae9b64da7fa056d)